### PR TITLE
Feature/clean code scruntinizer

### DIFF
--- a/Services/ElasticaQuerySorter.php
+++ b/Services/ElasticaQuerySorter.php
@@ -22,25 +22,28 @@ class ElasticaQuerySorter
     protected $sessionData;
     protected $configuration;
 
-    const NO_LIMIT = 99999;
+    const NO_LIMIT             = 99999;
+    const SESSION_QUERY_SORTER = 'alpixel_elastica_query_sorter';
 
     public function __construct(RequestStack $requestStack, Session $session, $configuration)
     {
-        $this->session = $session;
         $this->request = $requestStack->getCurrentRequest();
+        if (empty($this->request)) {
+            return;
+        }
+
+        $this->session = $session;
         $this->configuration['item_per_page'] = $configuration;
 
-        if (isset($this->request) && isset($this->request->query)) {
-            if ($this->request->query->has('clear_sort')) {
-                $this->session->remove('elastica_query_sorter');
-            }
+        if (isset($this->request->query) && $this->request->query->has('clear_sort') === true) {
+            $this->session->remove(self::SESSION_QUERY_SORTER);
         }
 
         //Initializing the data in session
-        if (!$this->session->has('elastica_query_sorter')) {
+        if (!$this->session->has(self::SESSION_QUERY_SORTER)) {
             $this->sessionData = [];
         } else {
-            $this->sessionData = $this->session->get('elastica_query_sorter');
+            $this->sessionData = $this->session->get(self::SESSION_QUERY_SORTER);
         }
     }
 
@@ -116,8 +119,8 @@ class ElasticaQuerySorter
 
     public function fetchData($key)
     {
-        $pageKey = (!empty($this->request)) ? $this->request->getPathInfo() : null;
-        $query   = (!empty($this->request)) ? $this->request->query : null;
+        $pageKey = $this->request->getPathInfo();
+        $query   = $this->request->query;
 
         if ($query === null) {
             return;
@@ -125,16 +128,17 @@ class ElasticaQuerySorter
 
         //Analyzing the session object to see if there is data in it
         //If data is given from Request, it will be override the session data
-        if (array_key_exists($pageKey, $this->sessionData) && !$query->has($key)) {
-            if (isset($this->sessionData[$pageKey][$key])) {
+        if (array_key_exists($pageKey, $this->sessionData) &&
+            !$query->has($key) &&
+            isset($this->sessionData[$pageKey][$key])) {
                 return $this->sessionData[$pageKey][$key];
-            }
         }
 
         if ($query->has('sortBy')) {
             $value = $query->get($key);
             $this->sessionData[$pageKey][$key] = $value;
             $this->storeSessionData();
+
             return $value;
         }
 
@@ -143,7 +147,7 @@ class ElasticaQuerySorter
 
     public function storeSessionData()
     {
-        $this->session->set('elastica_query_sorter', $this->sessionData);
+        $this->session->set(self::SESSION_QUERY_SORTER, $this->sessionData);
     }
 
     /**

--- a/Services/ElasticaQuerySorter.php
+++ b/Services/ElasticaQuerySorter.php
@@ -20,6 +20,7 @@ class ElasticaQuerySorter
     protected $session;
     protected $request;
     protected $sessionData;
+    protected $configuration;
 
     const NO_LIMIT = 99999;
 


### PR DESCRIPTION
- Fix scruntinizer

[juste ici ](https://github.com/alpixel/AlpixelElasticaQuerySorterBundle/compare/feature/clean-code-scruntinizer?expand=1#diff-05461ab7b6661069156b6908671d0a33R31) je fais un return direct si $request est vide ça évite du code pour rien [surtout ici on test $request](https://github.com/alpixel/AlpixelElasticaQuerySorterBundle/compare/feature/clean-code-scruntinizer?expand=1#diff-05461ab7b6661069156b6908671d0a33L118) je ne sait pas si ça te va ?

Ça évite également les multiple conditions dans la fonction [fetchData()](https://github.com/alpixel/AlpixelElasticaQuerySorterBundle/compare/feature/clean-code-scruntinizer?expand=1#diff-05461ab7b6661069156b6908671d0a33R120) que Scruntinizer n'aime pas.

Edit : 

Également ici j'ai ajouté la const [SESSION_QUERY_SORTE](https://github.com/alpixel/AlpixelElasticaQuerySorterBundle/compare/feature/clean-code-scruntinizer?expand=1#diff-05461ab7b6661069156b6908671d0a33R26) je pense que c'est une bonne pratique de mettre les clé de session en constante.
